### PR TITLE
Support tree_node and category for navigation #4721

### DIFF
--- a/templates/webshop/_helpers.jinja
+++ b/templates/webshop/_helpers.jinja
@@ -119,3 +119,57 @@
 
 </ul>
 {% endmacro %}
+
+
+{% macro nav_from_category(root_category) %}
+  {# render the children of the given category as menu #}
+  {% for category in root_category.childs %}
+    <li>
+      <a class="main-link" href="{{ url_for('product.category.render', uri=category.uri) }}">{{ category.name }}</a>
+      {% if category.childs %}
+      <!-- Dropdown Menu Starts-->
+      <div class="container menbg">
+        <div class="row">
+          {% for child in category.childs %}
+          <div class="col-md-2">
+            <ul class="list-unstyled">
+              <li><a href="{{ url_for('product.category.render', uri=child.uri) }}"><strong>{{ child.name }}</strong></a></li>
+              {% for grandchild in child.childs %}
+              <li><a href="{{ url_for('product.category.render', uri=grandchild.uri) }}">{{ grandchild.name }}</a></li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+    </li>
+  {% endfor %}
+{% endmacro %}
+
+
+{% macro nav_from_tree_node(root_node) %}
+  {# render the children of the given node as menu #}
+  {% for node in root_node.children %}
+    <li>
+      <a class="main-link" href="{{ url_for('product.tree_node.render', active_id=node.id, slug=node.slug) }}">{{ node.name }}</a>
+      {% if node.childs %}
+      <!-- Dropdown Menu Starts-->
+      <div class="container menbg">
+        <div class="row">
+          {% for child in node.children %}
+          <div class="col-md-2">
+            <ul class="list-unstyled">
+              <li><a href="{{ url_for('product.tree_node.render', active_id=child.id, slug=child.slug) }}"><strong>{{ child.name }}</strong></a></li>
+              {% for grandchild in child.children %}
+              <li><a href="{{ url_for('product.tree_node.render', active_id=grandchild.id, slug=grandchild.slug) }}">{{ grandchild.name }}</a></li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+    </li>
+  {% endfor %}
+{% endmacro %}

--- a/templates/webshop/base.jinja
+++ b/templates/webshop/base.jinja
@@ -164,28 +164,13 @@
         <div class="row main-navigation">
           <div class="col-md-12">
             <ul class="list-inline" id="nav-list">
-              {% for category in root_categories() %}
-              <li>
-                <a class="main-link" href="{{ url_for('product.category.render', uri=category.uri) }}">{{ category.name }}</a>
-                {% if category.childs %}
-                <!-- Dropdown Menu Starts-->
-                <div class="container menbg">
-                  <div class="row">
-                    {% for child in category.childs %}
-                    <div class="col-md-2">
-                      <ul class="list-unstyled">
-                        <li><a href="{{ url_for('product.category.render', uri=child.uri) }}"><strong>{{ child.name }}</strong></a></li>
-                        {% for grandchild in child.childs %}
-                        <li><a href="{{ url_for('product.category.render', uri=grandchild.uri) }}">{{ grandchild.name }}</a></li>
-                        {% endfor %}
-                      </ul>
-                    </div>
-                    {% endfor %}
-                  </div>
-                </div>
-                {% endif %}
-              </li>
-              {% endfor %}
+              {% from '_helpers.jinja' import nav_from_category, nav_from_tree_node %}
+              {% if request.nereid_website.root_navigation_model == 'product.tree_node' %}
+                {{ nav_from_tree_node(request.nereid_website.root_tree_node) }}
+              {% elif request.nereid_website.root_navigation_model == 'product.category' %}
+                {{ nav_from_category(request.nereid_website.root_category) }}
+              {% endif %}
+              {# add any other navigational elements like probably an article list or custom link here #}
             </ul>
           </div>
         </div>


### PR DESCRIPTION
product.tree_node is a far better hierarchial classification system
than product.category. Despite this, some sites may want to stay simple
and use category (which they might already use) for navigation.

This patch separates the rendering of top site navigation into _helpers
as two macros, for category and tree_node. Depending on the root navigation
model specified for the current website, the appropriate one is used
