### PR TITLE
Replacing nereid_user by current_user in sale confirmation templates.

### DIFF
--- a/templates/webshop/emails/sale-confirmation-html.jinja
+++ b/templates/webshop/emails/sale-confirmation-html.jinja
@@ -1,5 +1,5 @@
 {% trans %}
-Dear {% endtrans %} {{ nereid_user.display_name }}{% trans %},
+Dear {% endtrans %} {{ current_user.display_name }}{% trans %},
 <br/>
 <br/>
 Thank you for shopping from our store.{% endtrans %}

--- a/templates/webshop/emails/sale-confirmation-text.jinja
+++ b/templates/webshop/emails/sale-confirmation-text.jinja
@@ -1,5 +1,5 @@
 {% trans %}
-Dear {% endtrans %} {{ nereid_user.display_name }}{% trans %},
+Dear {% endtrans %} {{ current_user.display_name }}{% trans %},
 
 Thank you for shopping from our store.{% endtrans %}
 


### PR DESCRIPTION
- nereid_user is not in the context, while current_user is.
- Refers also to https://github.com/openlabs/nereid-checkout/pull/33
