### PR TITLE
Changed product.rec_name to product.name on product page #6885

### DIFF
--- a/templates/webshop/product.jinja
+++ b/templates/webshop/product.jinja
@@ -379,7 +379,7 @@
         $('.product-price').text(product.price);
 
         // Set only, no removals
-        $('.product-name').text(product.rec_name);
+        $('.product-name').text(product.name);
         // Set the correct product in all input field
         $('input[name="product"]').val(product.id);
 


### PR DESCRIPTION
When variant matching is done, the product-name text is set as `product.name`.